### PR TITLE
fix: integration test factory repair + CI pipeline hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
           --results-directory TestResults
 
       - name: Run integration tests
-        continue-on-error: true  # Integration tests require service fixes tracked separately
         run: >
           dotnet test
           apps/life-api-tests/LifeApi.IntegrationTests/LifeApi.IntegrationTests.csproj
@@ -196,6 +195,9 @@ jobs:
 
       - name: Build shared packages
         run: pnpm --filter @life-manager/schema build
+
+      - name: Validate production compose file
+        run: docker compose -f docker-compose.production.yml config --quiet
 
       - name: Restore .NET dependencies
         run: dotnet restore apps/life-api/LifeApi.csproj

--- a/apps/life-api-tests/LifeApi.IntegrationTests/Features/Auth/AuthControllerTests.cs
+++ b/apps/life-api-tests/LifeApi.IntegrationTests/Features/Auth/AuthControllerTests.cs
@@ -38,6 +38,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>
         var request = new RegisterRequest
         {
             Email = $"test{Guid.NewGuid()}@example.com", // Unique email
+            Username = $"u{Guid.NewGuid():N}"[..16],
             Password = "Password123!"
         };
 
@@ -62,6 +63,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>
         var firstRequest = new RegisterRequest
         {
             Email = email,
+            Username = $"u{Guid.NewGuid():N}"[..16],
             Password = "Password123!"
         };
         await _client.PostAsJsonAsync("/api/v1/auth/register", firstRequest);
@@ -70,6 +72,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>
         var secondRequest = new RegisterRequest
         {
             Email = email,
+            Username = $"u{Guid.NewGuid():N}"[..16],
             Password = "DifferentPassword123!"
         };
 
@@ -87,6 +90,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>
         var request = new RegisterRequest
         {
             Email = "not-an-email",
+            Username = $"u{Guid.NewGuid():N}"[..16],
             Password = "Password123!"
         };
 
@@ -111,6 +115,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>
         var registerRequest = new RegisterRequest
         {
             Email = email,
+            Username = $"u{Guid.NewGuid():N}"[..16],
             Password = password
         };
         await _client.PostAsJsonAsync("/api/v1/auth/register", registerRequest);
@@ -144,6 +149,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>
         var registerRequest = new RegisterRequest
         {
             Email = email,
+            Username = $"u{Guid.NewGuid():N}"[..16],
             Password = "CorrectPassword123!"
         };
         await _client.PostAsJsonAsync("/api/v1/auth/register", registerRequest);
@@ -190,6 +196,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>
         var registerRequest = new RegisterRequest
         {
             Email = email,
+            Username = $"u{Guid.NewGuid():N}"[..16],
             Password = "Password123!"
         };
         var registerResponse = await _client.PostAsJsonAsync("/api/v1/auth/register", registerRequest);
@@ -228,6 +235,7 @@ public class AuthControllerTests : IClassFixture<CustomWebApplicationFactory>
         var registerRequest = new RegisterRequest
         {
             Email = email,
+            Username = $"u{Guid.NewGuid():N}"[..16],
             Password = "Password123!"
         };
         var registerResponse = await _client.PostAsJsonAsync("/api/v1/auth/register", registerRequest);

--- a/apps/life-api-tests/LifeApi.IntegrationTests/Features/Events/EventsControllerTests.cs
+++ b/apps/life-api-tests/LifeApi.IntegrationTests/Features/Events/EventsControllerTests.cs
@@ -34,6 +34,7 @@ public class EventsControllerTests : IClassFixture<CustomWebApplicationFactory>
         var registerRequest = new RegisterRequest
         {
             Email = $"eventtest{Guid.NewGuid()}@example.com",
+            Username = $"u{Guid.NewGuid():N}"[..16],
             Password = "Password123!"
         };
 

--- a/apps/life-api-tests/LifeApi.IntegrationTests/Features/Tasks/TasksControllerTests.cs
+++ b/apps/life-api-tests/LifeApi.IntegrationTests/Features/Tasks/TasksControllerTests.cs
@@ -32,6 +32,7 @@ public class TasksControllerTests : IClassFixture<CustomWebApplicationFactory>
         var registerRequest = new RegisterRequest
         {
             Email = $"tasktest{Guid.NewGuid()}@example.com",
+            Username = $"u{Guid.NewGuid():N}"[..16],
             Password = "Password123!"
         };
 

--- a/apps/life-api-tests/LifeApi.IntegrationTests/Helpers/CustomWebApplicationFactory.cs
+++ b/apps/life-api-tests/LifeApi.IntegrationTests/Helpers/CustomWebApplicationFactory.cs
@@ -17,6 +17,11 @@ namespace LifeApi.IntegrationTests.Helpers;
 /// </summary>
 public class CustomWebApplicationFactory : WebApplicationFactory<Program>
 {
+    // Fixed name per factory instance — all requests share the same in-memory database.
+    // Must be a field (not inline Guid.NewGuid() in the lambda) because DbContextOptions
+    // is registered as Scoped by default; the lambda would otherwise re-evaluate per request.
+    private readonly string _dbName = $"InMemoryTestDb_{Guid.NewGuid()}";
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.ConfigureAppConfiguration((context, config) =>
@@ -40,17 +45,10 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
                 services.Remove(descriptor);
             }
 
-            // Use a unique in-memory database per factory instance to prevent test pollution
             services.AddDbContext<FinanceDbContext>(options =>
             {
-                options.UseInMemoryDatabase($"InMemoryTestDb_{Guid.NewGuid()}");
+                options.UseInMemoryDatabase(_dbName);
             });
-
-            // Build the service provider and create the database
-            var sp = services.BuildServiceProvider();
-            using var scope = sp.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<FinanceDbContext>();
-            db.Database.EnsureCreated();
         });
     }
 }

--- a/apps/life-api-tests/LifeApi.IntegrationTests/Helpers/CustomWebApplicationFactory.cs
+++ b/apps/life-api-tests/LifeApi.IntegrationTests/Helpers/CustomWebApplicationFactory.cs
@@ -2,13 +2,14 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
 using LifeApi.Data;
 
 namespace LifeApi.IntegrationTests.Helpers;
 
 /// <summary>
 /// Custom WebApplicationFactory for integration testing
-/// 
+///
 /// Learning Topics:
 /// - WebApplicationFactory for testing ASP.NET Core apps
 /// - Overriding services for testing (use in-memory database instead of PostgreSQL)
@@ -18,6 +19,16 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
 {
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
+        builder.ConfigureAppConfiguration((context, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Jwt:Secret"] = "test-secret-key-minimum-32-characters-long",
+                ["Jwt:Issuer"] = "life-manager-test",
+                ["Jwt:Audience"] = "life-manager-test",
+            });
+        });
+
         builder.ConfigureServices(services =>
         {
             // Remove the existing DbContext registration
@@ -29,19 +40,16 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
                 services.Remove(descriptor);
             }
 
-            // Add DbContext using in-memory database for testing
+            // Use a unique in-memory database per factory instance to prevent test pollution
             services.AddDbContext<FinanceDbContext>(options =>
             {
-                options.UseInMemoryDatabase("InMemoryTestDb");
+                options.UseInMemoryDatabase($"InMemoryTestDb_{Guid.NewGuid()}");
             });
 
             // Build the service provider and create the database
             var sp = services.BuildServiceProvider();
             using var scope = sp.CreateScope();
-            var scopedServices = scope.ServiceProvider;
-            var db = scopedServices.GetRequiredService<FinanceDbContext>();
-
-            // Ensure the database is created
+            var db = scope.ServiceProvider.GetRequiredService<FinanceDbContext>();
             db.Database.EnsureCreated();
         });
     }

--- a/apps/life-api/Program.cs
+++ b/apps/life-api/Program.cs
@@ -128,10 +128,9 @@ builder.Services.AddScoped<ILabelsService, LabelsService>();
 builder.Services.AddDbContext<FinanceDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
 
-// Configure JWT Authentication (compatible with Node.js API)
-var jwtSecret = builder.Configuration["Jwt:Secret"] ?? throw new InvalidOperationException("JWT Secret is not configured");
-var key = Encoding.ASCII.GetBytes(jwtSecret);
-
+// Configure JWT Authentication
+// NOTE: jwtSecret is read inside the lambda so it is evaluated lazily (after Build()),
+// ensuring WebApplicationFactory.ConfigureAppConfiguration overrides are visible.
 builder.Services.AddAuthentication(options =>
 {
     options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
@@ -139,6 +138,8 @@ builder.Services.AddAuthentication(options =>
 })
 .AddJwtBearer(options =>
 {
+    var jwtSecret = builder.Configuration["Jwt:Secret"] ?? throw new InvalidOperationException("JWT Secret is not configured");
+    var key = Encoding.ASCII.GetBytes(jwtSecret);
     options.RequireHttpsMetadata = false;
     options.SaveToken = true;
     options.TokenValidationParameters = new TokenValidationParameters

--- a/apps/life-api/appsettings.json
+++ b/apps/life-api/appsettings.json
@@ -12,7 +12,9 @@
   },
   "Jwt": {
     "Secret": "your-secret-key-change-in-production",
-    "ExpiresIn": "1h"
+    "ExpiresIn": "1h",
+    "Issuer": "life-manager-dev",
+    "Audience": "life-manager-dev"
   },
   "RateLimit": {
     "Enabled": true,


### PR DESCRIPTION
## Summary

- Fix `CustomWebApplicationFactory` to inject JWT config via `ConfigureAppConfiguration` (resolves auth token setup failures in integration tests)
- Use unique in-memory DB name per factory instance (`InMemoryTestDb_{Guid}`) to prevent test pollution between parallel test runs
- Add `Jwt:Issuer` and `Jwt:Audience` to `appsettings.json` for dev environment
- Remove `continue-on-error: true` from integration test step in `ci.yml` — integration tests now gate the build
- Add `docker compose -f docker-compose.production.yml config --quiet` validation step to the `build` job

## Test plan

- [x] 186 unit tests pass locally
- [ ] Integration tests pass on CI (this PR proves it by removing continue-on-error)
- [ ] Build Check job validates compose file syntax