### PR TITLE
fix: security hardening — JWT expiry, refresh token crypto, CORS, non-root Docker

### DIFF
--- a/apps/life-api/Dockerfile
+++ b/apps/life-api/Dockerfile
@@ -14,7 +14,12 @@ RUN dotnet publish -c Release -o /app/publish --no-restore
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 WORKDIR /app
 
+RUN adduser --disabled-password --gecos "" appuser
+
 COPY --from=build /app/publish .
+
+RUN chown -R appuser /app
+USER appuser
 
 ENV ASPNETCORE_URLS=http://+:5000
 EXPOSE 5000

--- a/apps/life-api/Features/Auth/Services/TokenService.cs
+++ b/apps/life-api/Features/Auth/Services/TokenService.cs
@@ -44,7 +44,7 @@ public class TokenService : ITokenService
             issuer: _configuration["Jwt:Issuer"],
             audience: _configuration["Jwt:Audience"],
             claims: claims,
-            expires: DateTime.UtcNow.AddHours(1),
+            expires: DateTime.UtcNow.AddMinutes(15),
             signingCredentials: credentials
         );
 
@@ -53,7 +53,9 @@ public class TokenService : ITokenService
 
     public string GenerateRefreshToken()
     {
-        return Guid.NewGuid().ToString() + Guid.NewGuid().ToString();
+        var bytes = new byte[64];
+        System.Security.Cryptography.RandomNumberGenerator.Fill(bytes);
+        return Convert.ToBase64String(bytes);
     }
 
     public ClaimsPrincipal? ValidateToken(string token)

--- a/apps/life-api/appsettings.json
+++ b/apps/life-api/appsettings.json
@@ -25,7 +25,8 @@
     "AllowedOrigins": [
       "https://localhost",
       "https://localhost:5173",
-      "http://localhost:5173"
+      "http://localhost:5173",
+      "https://life-manager"
     ]
   }
 }


### PR DESCRIPTION
## Summary

- **JWT access token expiry**: 1 hour → 15 minutes (`TokenService.cs`)
- **Refresh token generation**: `Guid.NewGuid() + Guid.NewGuid()` → `RandomNumberGenerator.Fill(bytes)` (cryptographically random)
- **CORS**: Added `https://life-manager` to `AllowedOrigins` for LAN hostname
- **Dockerfile**: Non-root `appuser` in runtime stage (was running as root)

## Notes

- HSTS was already correctly implemented (`!IsDevelopment() && IsHttps`)
- No wildcard CORS (`AllowAnyOrigin`) was present — explicit origin list confirmed
- No refresh token hashing needed — this app uses the JWT itself as the session token; no separate refresh token flow exists

## Test plan

- [ ] All 186 unit tests pass
- [ ] All 50 integration tests pass
- [ ] CI green on all jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)