### PR TITLE
docs: LAN deployment — production env JWT issuer/audience, docker-compose wiring

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -13,6 +13,13 @@ DB_PASSWORD=CHANGE_ME_STRONG_PASSWORD
 #   [Convert]::ToBase64String((1..64 | ForEach-Object { Get-Random -Maximum 256 }) -as [byte[]])
 JWT_SECRET=CHANGE_ME_64_CHARACTER_RANDOM_SECRET_KEY
 
+# ── JWT Issuer / Audience ──────────────────────────────────────────────────────
+# Must match the hostname used in the browser.
+# For localhost access:    https://localhost
+# For LAN hostname access: https://life-manager
+JWT_ISSUER=https://life-manager
+JWT_AUDIENCE=https://life-manager
+
 # ── Frontend API URL ───────────────────────────────────────────────────────────
 # Baked into the frontend bundle at build time.
 # The API is proxied through nginx, so use just the origin (no port, no /api path).

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -53,6 +53,8 @@ services:
       ASPNETCORE_ENVIRONMENT: Production
       ConnectionStrings__DefaultConnection: "Host=postgres;Port=5432;Database=${DB_NAME:-life_manager_prod};Username=${DB_USER:-life_manager};Password=${DB_PASSWORD}"
       Jwt__Secret: ${JWT_SECRET}
+      Jwt__Issuer: ${JWT_ISSUER:-https://life-manager}
+      Jwt__Audience: ${JWT_AUDIENCE:-https://life-manager}
       Cors__AllowedOrigins__0: "https://localhost"
       Cors__AllowedOrigins__1: ${FRONTEND_ORIGIN:-https://localhost}
     depends_on:


### PR DESCRIPTION
## Summary

- **`.env.production.example`**: added `JWT_ISSUER` and `JWT_AUDIENCE` variables with comments explaining they must match the browser hostname
- **`docker-compose.production.yml`**: added `Jwt__Issuer` and `Jwt__Audience` environment variables to the `api` service (defaults to `https://life-manager`)
- **`docs/guides/HTTPS-SETUP.md`**: already exists and is comprehensive — no changes needed

## Test plan

- [ ] `docker compose -f docker-compose.production.yml config --quiet` passes (no syntax errors)
- [ ] CI green on all jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)